### PR TITLE
ItalicPlaceholderEffect iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Included effects:
 | SizeFontToFitEffect | Shrinks fonts to fit | x | x | Todo |
 | MultiLineLabelEffect | Limit lines to given amount | x | x | x |
 | CustomFontEffect | Custom font for a Label | x | x | Todo |
+| ItalicPlaceholderEffect | Italicizes Placeholder of an Entry | x | Todo? | - |
 
 ###### iOS
 

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/Effects/ItalicPlaceholderEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/Effects/ItalicPlaceholderEffect.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using FormsCommunityToolkit.Effects.iOS.Effects;
+using Foundation;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(ItalicPlaceholderEffect), nameof(ItalicPlaceholderEffect))]
+namespace FormsCommunityToolkit.Effects.iOS.Effects
+{
+	[Preserve(AllMembers = true)]
+	public class ItalicPlaceholderEffect : PlatformEffect
+	{
+		NSAttributedString _old;
+
+		protected override void OnAttached()
+		{
+			var entry = Control as UITextField;
+			if (entry != null && !string.IsNullOrWhiteSpace(entry.Placeholder))
+			{
+				_old = entry.AttributedPlaceholder;
+				var entryFontSize = entry.Font.PointSize;
+				entry.AttributedPlaceholder = new NSAttributedString(entry.Placeholder, font: UIFont.ItalicSystemFontOfSize(entryFontSize));
+			}
+		}
+
+		protected override void OnDetached()
+		{
+			var entry = Control as UITextField;
+			if (entry != null)
+			{
+				entry.AttributedPlaceholder = _old;
+			}
+		}
+	}
+}

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/Effects/ItalicPlaceholderEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/Effects/ItalicPlaceholderEffect.cs
@@ -8,29 +8,29 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: ExportEffect(typeof(ItalicPlaceholderEffect), nameof(ItalicPlaceholderEffect))]
 namespace FormsCommunityToolkit.Effects.iOS.Effects
 {
-	[Preserve(AllMembers = true)]
-	public class ItalicPlaceholderEffect : PlatformEffect
-	{
-		private NSAttributedString _old;
+    [Preserve(AllMembers = true)]
+    public class ItalicPlaceholderEffect : PlatformEffect
+    {
+        private NSAttributedString _old;
 
-		protected override void OnAttached()
-		{
-			var entry = Control as UITextField;
-			if (entry != null && !string.IsNullOrWhiteSpace(entry.Placeholder))
-			{
-				_old = entry.AttributedPlaceholder;
-				var entryFontSize = entry.Font.PointSize;
-				entry.AttributedPlaceholder = new NSAttributedString(entry.Placeholder, font: UIFont.ItalicSystemFontOfSize(entryFontSize));
-			}
-		}
+        protected override void OnAttached()
+        {
+            var entry = Control as UITextField;
+            if (entry != null && !string.IsNullOrWhiteSpace(entry.Placeholder))
+            {
+                _old = entry.AttributedPlaceholder;
+                var entryFontSize = entry.Font.PointSize;
+                entry.AttributedPlaceholder = new NSAttributedString(entry.Placeholder, font: UIFont.ItalicSystemFontOfSize(entryFontSize));
+            }
+        }
 
-		protected override void OnDetached()
-		{
-			var entry = Control as UITextField;
-			if (entry != null)
-			{
-				entry.AttributedPlaceholder = _old;
-			}
-		}
-	}
+        protected override void OnDetached()
+        {
+            var entry = Control as UITextField;
+            if (entry != null)
+            {
+                entry.AttributedPlaceholder = _old;
+            }
+        }
+    }
 }

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/Effects/ItalicPlaceholderEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/Effects/ItalicPlaceholderEffect.cs
@@ -11,7 +11,7 @@ namespace FormsCommunityToolkit.Effects.iOS.Effects
 	[Preserve(AllMembers = true)]
 	public class ItalicPlaceholderEffect : PlatformEffect
 	{
-		NSAttributedString _old;
+		private NSAttributedString _old;
 
 		protected override void OnAttached()
 		{

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/FormsCommunityToolkit.Effects.iOS.csproj
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.iOS/FormsCommunityToolkit.Effects.iOS.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Effects\SizeFontToFitEffect.cs" />
     <Compile Include="Effects\ChangeColorSwitchEffect.cs" />
     <Compile Include="Effects\CustomFontEffect.cs" />
+    <Compile Include="Effects\ItalicPlaceholderEffect.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FormsCommunityToolkit.Effects\FormsCommunityToolkit.Effects.csproj">

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.csproj
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.csproj
@@ -46,6 +46,7 @@
     <Compile Include="DisableAutoCorrectEffect.cs" />
     <Compile Include="SizeFontToFitEffect.cs" />
     <Compile Include="CustomFontEffect.cs" />
+    <Compile Include="ItalicPlaceholderEffect.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/ItalicPlaceholderEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/ItalicPlaceholderEffect.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace FormsCommunityToolkit.Effects
+{
+	public class ItalicPlaceholderEffect : RoutingEffect
+	{
+		public ItalicPlaceholderEffect() : base("Organon.Effects.ItalicPlaceholderEffect")
+		{
+		}
+	}
+}

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/ItalicPlaceholderEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/ItalicPlaceholderEffect.cs
@@ -3,10 +3,10 @@ using Xamarin.Forms;
 
 namespace FormsCommunityToolkit.Effects
 {
-	public class ItalicPlaceholderEffect : RoutingEffect
-	{
-		public ItalicPlaceholderEffect() : base("Organon.Effects.ItalicPlaceholderEffect")
-		{
-		}
-	}
+    public class ItalicPlaceholderEffect : RoutingEffect
+    {
+        public ItalicPlaceholderEffect() : base("Organon.Effects.ItalicPlaceholderEffect")
+        {
+        }
+    }
 }

--- a/src/SampleApp/Effects.SampleApp/Views/EntryPage.xaml
+++ b/src/SampleApp/Effects.SampleApp/Views/EntryPage.xaml
@@ -41,5 +41,11 @@
         <effects:DisableAutoCorrectEffect />
       </Entry.Effects>
     </Entry>
+	<Label Text="ItalicPlaceholderEffect" Margin="0,20,0,0"/>
+    <Entry Placeholder="start typing..." VerticalOptions="Start">
+      <Entry.Effects>
+        <effects:ItalicPlaceholderEffect />
+      </Entry.Effects>
+    </Entry>
   </StackLayout>
 </ContentPage>


### PR DESCRIPTION
Makes the placeholder of an Entry italic. Haven't looked into if this is necessary/possible on Android/UWP.