### PR TITLE
[UWP] Add SearchBarSuggestionEffect

### DIFF
--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.UWP/Effects/UWPSearchBarSuggestionEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.UWP/Effects/UWPSearchBarSuggestionEffect.cs
@@ -1,0 +1,56 @@
+﻿using FormsCommunityToolkit.Effects.UWP.Effects;
+using System;
+using System.Collections.ObjectModel;
+using Windows.UI.Xaml.Controls;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.UWP;
+using System.ComponentModel;
+
+[assembly: ExportEffect(typeof(UWPSearchBarSuggestionEffect), nameof(UWPSearchBarSuggestionEffect))]
+namespace FormsCommunityToolkit.Effects.UWP.Effects
+{
+	public class UWPSearchBarSuggestionEffect : PlatformEffect
+	{
+		protected override void OnAttached()
+		{
+			var autoSuggestBox = Control as AutoSuggestBox;
+			if (autoSuggestBox != null)
+			{
+				autoSuggestBox.SuggestionChosen += OnSuggestionChosen;
+				autoSuggestBox.TextChanged += OnTextChangedEffect;
+				autoSuggestBox.AutoMaximizeSuggestionArea = true;
+				autoSuggestBox.ItemsSource = SearchBarSuggestionEffect.GetSuggestions(Element);
+			}
+		}
+
+		protected override void OnDetached()
+		{
+			var autoSuggestBox = Control as AutoSuggestBox;
+			autoSuggestBox.SuggestionChosen -= OnSuggestionChosen;
+			autoSuggestBox.TextChanged -= OnTextChangedEffect;
+		}
+
+		private void OnSuggestionChosen(AutoSuggestBox sender, AutoSuggestBoxSuggestionChosenEventArgs args)
+		{
+			((IElementController)Element).SetValueFromRenderer(SearchBar.TextProperty, sender.Text);
+		}
+
+		private void OnTextChangedEffect(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs e)
+		{
+			Action platformSpecificAction = (Action)Element.GetValue(SearchBarSuggestionEffect.TextChangedActionProperty);
+			platformSpecificAction?.Invoke();
+		}
+
+		protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(args);
+			if (args.PropertyName == SearchBarSuggestionEffect.SuggestionsProperty.PropertyName)
+				UpdateItemsSource();
+		}
+
+		private void UpdateItemsSource()
+		{
+			((AutoSuggestBox)Control).ItemsSource = SearchBarSuggestionEffect.GetSuggestions(Element);
+		}
+	}
+}

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.UWP/FormsCommunityToolkit.Effects.UWP.csproj
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.UWP/FormsCommunityToolkit.Effects.UWP.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Effects\CapitalizeKeyboardEffect.cs" />
     <Compile Include="Effects\MultiLineLabelEffect.cs" />
     <Compile Include="Effects\RemoveBorderEffect.cs" />
+    <Compile Include="Effects\UWPSearchBarSuggestionEffect.cs" />
     <Compile Include="Effects\ViewBlurEffect.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VisualTreeExtensions.cs" />

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.csproj
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects.csproj
@@ -44,6 +44,7 @@
     <Compile Include="CapitializeKeyboardEffect.cs" />
     <Compile Include="RemoveBorderEffect.cs" />
     <Compile Include="DisableAutoCorrectEffect.cs" />
+    <Compile Include="SearchBarSuggestionEffect.cs" />
     <Compile Include="SizeFontToFitEffect.cs" />
     <Compile Include="CustomFontEffect.cs" />
     <Compile Include="ItalicPlaceholderEffect.cs" />

--- a/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/SearchBarSuggestionEffect.cs
+++ b/src/FormsCommunityToolkit.Effects/FormsCommunityToolkit.Effects/SearchBarSuggestionEffect.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Forms;
+
+namespace FormsCommunityToolkit.Effects
+{
+	public static class SearchBarSuggestionEffect
+	{
+		public static readonly BindableProperty SuggestionsProperty = BindableProperty.CreateAttached("Suggestions", typeof(ObservableCollection<string>), typeof(SearchBarSuggestionEffect), new ObservableCollection<string>(), propertyChanged: OnSuggestionsChanged);
+		public static readonly BindableProperty TextChangedActionProperty = BindableProperty.CreateAttached("TextChangedAction", typeof(Action), typeof(SearchBarSuggestionEffect), null, propertyChanged: OnTextChangedActionChanged);
+
+		public static ObservableCollection<string> GetSuggestions(BindableObject view)
+		{
+			return (ObservableCollection<string>)view.GetValue(SuggestionsProperty);
+		}
+		
+		public static void SetSuggestions(BindableObject view, ObservableCollection<string> value)
+		{
+			view.SetValue(SuggestionsProperty, value);
+		}
+
+		public static Action GetTextChangedAction(BindableObject view)
+		{
+			return (Action)view.GetValue(TextChangedActionProperty);
+		}
+
+		public static void SetTextChangedAction(BindableObject view, Action value)
+		{
+			view.SetValue(TextChangedActionProperty, value);
+		}
+
+		private static void OnSuggestionsChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var view = bindable as SearchBar;
+			if (view == null)
+				return;
+
+			bindable.SetValue(SuggestionsProperty, (ObservableCollection<string>)newValue);
+		}
+		private static void OnTextChangedActionChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var view = bindable as SearchBar;
+			if (view == null)
+				return;
+
+			bindable.SetValue(TextChangedActionProperty, (Action)newValue);
+		}
+	}
+
+	public class UWPSearchBarSuggestionEffect : RoutingEffect
+	{
+		public UWPSearchBarSuggestionEffect() : base("FormsCommunityToolkit.Effects.UWPSearchBarSuggestionEffect")
+		{
+		}
+	}
+}

--- a/src/SampleApp/Effects.SampleApp/Effects.SampleApp.csproj
+++ b/src/SampleApp/Effects.SampleApp/Effects.SampleApp.csproj
@@ -45,6 +45,9 @@
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Views\SearchBarPage.xaml.cs">
+      <DependentUpon>SearchBarPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\SwitchPage.xaml.cs">
       <DependentUpon>SwitchPage.xaml</DependentUpon>
     </Compile>
@@ -108,6 +111,12 @@
       <Project>{67f9d3a8-f71e-4428-913f-c37ae82cdb24}</Project>
       <Name>FormsCommunityToolkit.Effects</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Views\SearchBarPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />

--- a/src/SampleApp/Effects.SampleApp/Views/MainPage.xaml
+++ b/src/SampleApp/Effects.SampleApp/Views/MainPage.xaml
@@ -16,6 +16,7 @@
         <Button x:Name="ViewButton" Text="View effects" Clicked="OnViewButtonClicked" />
         <Button x:Name="SwitchButton" Text="Switch effects" Clicked="OnSwitchButtonClicked" />
         <Button x:Name="LabelButton" Text="Label effects" Clicked="OnLabelButtonClicked" />
+        <Button x:Name="SearchBarButton" Text="SearchBar effects" Clicked="OnSearchBarButtonClicked" />
 	</StackLayout>
   
 </ContentPage>

--- a/src/SampleApp/Effects.SampleApp/Views/MainPage.xaml.cs
+++ b/src/SampleApp/Effects.SampleApp/Views/MainPage.xaml.cs
@@ -29,5 +29,10 @@ namespace FormsCommunityToolkit.Effects.SampleApp.Views
         {
             Navigation.PushAsync(new LabelPage());
         }
-    }
+
+		private void OnSearchBarButtonClicked(object sender, EventArgs args)
+		{
+			Navigation.PushAsync(new SearchBarPage());
+		}
+	}
 }

--- a/src/SampleApp/Effects.SampleApp/Views/SearchBarPage.xaml
+++ b/src/SampleApp/Effects.SampleApp/Views/SearchBarPage.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:effects="clr-namespace:FormsCommunityToolkit.Effects;assembly=FormsCommunityToolkit.Effects"
+             x:Class="FormsCommunityToolkit.Effects.SampleApp.Views.SearchBarPage">
+  <StackLayout>
+    <SearchBar x:Name="searchBar">
+      <SearchBar.Effects>
+        <effects:UWPSearchBarSuggestionEffect/>
+      </SearchBar.Effects>
+    </SearchBar>
+  </StackLayout>
+</ContentPage>

--- a/src/SampleApp/Effects.SampleApp/Views/SearchBarPage.xaml.cs
+++ b/src/SampleApp/Effects.SampleApp/Views/SearchBarPage.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms;
+
+namespace FormsCommunityToolkit.Effects.SampleApp.Views
+{
+	public partial class SearchBarPage : ContentPage
+	{
+		public SearchBarPage ()
+		{
+			InitializeComponent ();
+			var searchableValues = new ObservableCollection<string>();
+			for (int i = 1; i <= 50; i++)
+			{
+				searchableValues.Add("item " + i);
+			}
+
+			SearchBarSuggestionEffect.SetTextChangedAction(searchBar, new Action(() =>
+			{
+				if (searchBar.Text.Length == 0)
+				{
+					SearchBarSuggestionEffect.GetSuggestions(searchBar).Clear();
+				}
+				else
+				{
+					var filtered = searchableValues.Where(i => i.Contains(searchBar.Text.ToLower()));
+					SearchBarSuggestionEffect.GetSuggestions(searchBar).Clear();
+					foreach (string i in filtered)
+					{
+						SearchBarSuggestionEffect.GetSuggestions(searchBar).Add(i);
+					}
+				}
+			}));
+		}
+	}
+}


### PR DESCRIPTION
Hello all -- this was originally meant as a [PR](https://github.com/xamarin/Xamarin.Forms/pull/499) for adding a platform specific feature to Forms which enables suggestion area functionality on UWP, but it was decided that this could be an effect instead. If you're interested, feel free to use this since I spent some time converting it over. It only works on UWP which takes advantage of the `AutoSuggestBox`'s suggestions which we don't currently use. I _think_ this should work okay based on a small bit of testing against the sample app, but please feel free to make any suggestions or point out if I missed anything.

There are a couple of GIFs on that PR (which will probably be closed at some point, as it's lingered around as open); I have a separate [PR](https://github.com/xamarin/Xamarin.Forms/pull/646) that makes a change to the `AutoMaximizeSuggestionArea` value by itself (because we don't use the suggestions by default it can cause a weird screen shift in certain layouts because it assumes the suggestion area is there).

A side note is that it seems like there aren't any coding guidelines yet, so some of my formatting might be a little varied across files, if unintentionally.