### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,24 @@ Included effects:
 
 | Effect                     | Description | iOS | Android | UWP |
 |----------------------------|-------------|-----|---------|-----|
+| **ENTRY** |
 | CapitalizeKeyboardEffect | Enforces caps on the keyboard for an Entry | x | x | x |
 | ClearEntryEffect | Adds a clear button to an Entry | x | x | - |
+| DisableAutoCorrectEffect | Disables auto-correction and entry suggestions from an entry | x | x | - |
+| ItalicPlaceholderEffect | Italicizes Placeholder of an Entry | x | Todo? | - |
 | RemoveBorderEffect | Removes the border from an Entry on iOS | x | - | x |
 | RemoveEntryLineEffect | Removes the underline from an Entry on Android | - | x | - |
-| DisableAutoCorrectEffect | Disables auto-correction and entry suggestions from an entry | x | x | - |
-| ViewBlurEffect | Blur any view | x | Todo | x |
-| ChangeColorSwitchEffect | Change colors of switch | x | x | Todo |
-| SizeFontToFitEffect | Shrinks fonts to fit | x | x | Todo |
-| MultiLineLabelEffect | Limit lines to given amount | x | x | x |
-| CustomFontEffect | Custom font for a Label | x | x | Todo |
-| ItalicPlaceholderEffect | Italicizes Placeholder of an Entry | x | Todo? | - |
 | SelectAllTextEntryEffect | Select text in an Entry when receive focus | x | x | x |
+| **LABEL** |
+| CustomFontEffect | Custom font for a Label | x | x | Todo |
+| MultiLineLabelEffect | Limit lines to given amount | x | x | x |
+| SizeFontToFitEffect | Shrinks fonts to fit | x | x | Todo |
+| **PICKER** |
 | ChangeColorPickerEffect | Change colors of picker title | x | x | x |
+| **SWITCH** |
+| ChangeColorSwitchEffect | Change colors of switch | x | x | Todo |
+| **VIEW** |
+| ViewBlurEffect | Blur any view | x | Todo | x |
 
 ###### iOS
 


### PR DESCRIPTION
Separate effects per control

Please take a moment to fill out the following:

Changes Proposed in this pull request:
- Naming is not yet 100% so readme now shows effects per control category
-
- 